### PR TITLE
Set Correct Ruby Version for Heroku Deployment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source "https://rubygems.org"
 
+ruby "3.4.3"
+
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 8.0.2"
 # The modern asset pipeline for Rails [https://github.com/rails/propshaft]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -379,5 +379,8 @@ DEPENDENCIES
   tzinfo-data
   web-console
 
+RUBY VERSION
+   ruby 3.4.3p32
+
 BUNDLED WITH
    2.6.8


### PR DESCRIPTION
## Description

This PR adds explicit Ruby version specification to the Gemfile to ensure Heroku uses the correct Ruby version (3.4.3) during deployment.

## Changes Made

- Adds Ruby version specification to Gemfile:
  ```ruby
  ruby "3.4.3"
  ```
- This matches the version specified in `.ruby-version`

## Why This Change is Necessary

- Heroku requires explicit Ruby version specification in the Gemfile
- Currently, Heroku is defaulting to Ruby 3.3.7 instead of the desired 3.4.3
- This ensures consistent Ruby version across all environments

## Testing

1. After merging, deploy to Heroku
2. Verify Ruby version with:
   ```bash
   heroku run "ruby -v"
   ```
   Should output: `ruby 3.4.3`

## Related Issue

- Fixes #12 - Set correct ruby version on Heroku