### PR TITLE
fix(heroku): move esbuild to dependencies for production build

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,12 +7,12 @@
   },
   "devDependencies": {
     "autoprefixer": "^10.4.21",
-    "esbuild": "^0.25.3",
     "postcss": "^8.5.3",
     "tailwindcss": "^4.1.4"
   },
   "dependencies": {
-    "@tailwindcss/cli": "^4.1.4"
+    "@tailwindcss/cli": "^4.1.4",
+    "esbuild": "^0.25.3"
   },
   "engines": {
     "node": "24.3.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,13 +11,13 @@ importers:
       '@tailwindcss/cli':
         specifier: ^4.1.4
         version: 4.1.11
+      esbuild:
+        specifier: ^0.25.3
+        version: 0.25.5
     devDependencies:
       autoprefixer:
         specifier: ^10.4.21
         version: 10.4.21(postcss@8.5.6)
-      esbuild:
-        specifier: ^0.25.3
-        version: 0.25.5
       postcss:
         specifier: ^8.5.3
         version: 8.5.6


### PR DESCRIPTION
Moves esbuild from devDependencies to dependencies in package.json so Heroku can build assets in production. Fixes build error where esbuild is not found during assets:precompile.