### PR TITLE
fix: move tailwindcss, postcss, autoprefixer to dependencies for Heroku asset build

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,13 +6,13 @@
     "build:css": "npx @tailwindcss/cli -i ./app/assets/stylesheets/application.tailwind.css -o ./app/assets/builds/application.css --minify"
   },
   "devDependencies": {
-    "autoprefixer": "^10.4.21",
-    "postcss": "^8.5.3",
-    "tailwindcss": "^4.1.4"
   },
   "dependencies": {
     "@tailwindcss/cli": "^4.1.4",
-    "esbuild": "^0.25.3"
+    "esbuild": "^0.25.3",
+    "autoprefixer": "^10.4.21",
+    "postcss": "^8.5.3",
+    "tailwindcss": "^4.1.4"
   },
   "engines": {
     "node": "24.3.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,13 +11,12 @@ importers:
       '@tailwindcss/cli':
         specifier: ^4.1.4
         version: 4.1.11
-      esbuild:
-        specifier: ^0.25.3
-        version: 0.25.5
-    devDependencies:
       autoprefixer:
         specifier: ^10.4.21
         version: 10.4.21(postcss@8.5.6)
+      esbuild:
+        specifier: ^0.25.3
+        version: 0.25.5
       postcss:
         specifier: ^8.5.3
         version: 8.5.6


### PR DESCRIPTION
Moves Tailwind CSS and related packages to dependencies so Heroku can build assets in production.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management for styling tools to improve package handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->